### PR TITLE
Hide body and chestplate when swimming

### DIFF
--- a/Shared/src/main/java/dev/tr7zw/firstperson/mixins/ArmorFeatureRendererMixin.java
+++ b/Shared/src/main/java/dev/tr7zw/firstperson/mixins/ArmorFeatureRendererMixin.java
@@ -1,5 +1,6 @@
 package dev.tr7zw.firstperson.mixins;
 
+import net.minecraft.client.player.LocalPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -23,6 +24,7 @@ RenderLayer<T, M>{
 		super(context);
 	}
 
+	private boolean hideBody = false;
 	private boolean hideShoulders = false;
 	private boolean hideHelmet = false;
 	
@@ -31,12 +33,18 @@ RenderLayer<T, M>{
 			EquipmentSlot equipmentSlot, int i, A bipedEntityModel, CallbackInfo info) {
 		hideShoulders = equipmentSlot == EquipmentSlot.CHEST && FirstPersonModelCore.isRenderingPlayer && FirstPersonModelCore.config.vanillaHands;
 		hideHelmet = equipmentSlot == EquipmentSlot.HEAD && FirstPersonModelCore.isRenderingPlayer;
+		hideBody = equipmentSlot == EquipmentSlot.CHEST && FirstPersonModelCore.isRenderingPlayer && (livingEntity instanceof LocalPlayer player && player.isSwimming());
 	}
 	
 	@Inject(method = "renderModel", at = @At("HEAD"))
 	private void renderArmorParts(PoseStack matrixStack, MultiBufferSource vertexConsumerProvider, int i,
 			ArmorItem armorItem, boolean bl, A bipedEntityModel, boolean bl2, float f, float g, float h,
 			String string, CallbackInfo info) {
+
+		if (hideBody) {
+			bipedEntityModel.body.visible = false;
+		}
+
 		if(hideShoulders) {
 			bipedEntityModel.leftArm.visible = false;
 			bipedEntityModel.rightArm.visible = false;

--- a/Shared/src/main/java/dev/tr7zw/firstperson/mixins/PlayerRenderMixin.java
+++ b/Shared/src/main/java/dev/tr7zw/firstperson/mixins/PlayerRenderMixin.java
@@ -57,6 +57,9 @@ public abstract class PlayerRenderMixin
 			} else {
 				
 			}
+			if (abstractClientPlayerEntity.isSwimming()) {
+				playerEntityModel_1.body.visible = false;
+			}
 		} else {
 			playerEntityRenderer.getModel().hat.visible = playerEntityRenderer.getModel().hat.visible;
 		}


### PR DESCRIPTION
Body and Chestplate blocked the view of the player while swimming down.
Realistically this should not be possible while swimming so the body and chestplate can just be hidden while swimming.

https://github.com/tr7zw/FirstPersonModel/issues/264

![image](https://user-images.githubusercontent.com/67184131/177220469-eb2abfba-5547-4234-95d1-81647c4dd87a.png)