### PR TITLE
fix: hide ysm head in first person on 26.1 without breaking mod captures

### DIFF
--- a/src/main/java/dev/tr7zw/firstperson/FirstPersonModelCore.java
+++ b/src/main/java/dev/tr7zw/firstperson/FirstPersonModelCore.java
@@ -24,6 +24,15 @@ public abstract class FirstPersonModelCore extends FirstPersonBase {
     public static boolean enabled = true;
     @Deprecated
     public static boolean isRenderingPlayer = false;
+    /**
+     * True while the render state of the camera entity is being extracted and
+     * the mod is active. Widens {@link #isRenderingPlayer()} for mods that build
+     * their render data at extraction time (e.g. YSM), without marking the
+     * extracted states themselves, so captures of other mods (RealCamera, GUIs)
+     * evaluate with the flag down and keep rendering the full model with its
+     * head.
+     */
+    public static boolean cameraEntityExtract = false;
     private CameraType lastCameraType = null;
     @Deprecated
     private int tickCounterWorkaround = 0;
@@ -94,6 +103,19 @@ public abstract class FirstPersonModelCore extends FirstPersonBase {
             isHeld = false;
         }
         tickCounterWorkaround++;
+    }
+
+    @Override
+    public boolean isRenderingPlayer() {
+        return super.isRenderingPlayer() || cameraEntityExtract;
+    }
+
+    /**
+     * The un-widened flag. Only true while FirstPerson itself extracts/renders
+     * the camera entity, not for third party extractions.
+     */
+    public boolean isRenderingPlayerRaw() {
+        return super.isRenderingPlayer();
     }
 
     @Override

--- a/src/main/java/dev/tr7zw/firstperson/mixins/LivingEntityRendererMixin.java
+++ b/src/main/java/dev/tr7zw/firstperson/mixins/LivingEntityRendererMixin.java
@@ -181,8 +181,10 @@ public abstract class LivingEntityRendererMixin {
     @Inject(method = "extractRenderState(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;F)V", at = @At("HEAD"))
     private void checkIfCameraEntity(LivingEntity livingEntity, LivingEntityRenderState livingEntityRenderState,
             float f, CallbackInfo ci) {
+        // Raw flag: only states extracted by FirstPerson itself are marked, so
+        // third party captures (RealCamera, GUIs) keep rendering the head.
         ((LivingEntityRenderStateAccess) livingEntityRenderState)
-                .setIsCameraEntity(FirstPersonModelCore.instance.isRenderingPlayer());
+                .setIsCameraEntity(FirstPersonModelCore.instance.isRenderingPlayerRaw());
     }
     //? }
 

--- a/src/main/java/dev/tr7zw/firstperson/mixins/PlayerMixin.java
+++ b/src/main/java/dev/tr7zw/firstperson/mixins/PlayerMixin.java
@@ -19,7 +19,7 @@ public class PlayerMixin {
 
     @Inject(method = "getItemBySlot", at = @At("HEAD"), cancellable = true)
     public void getItemBySlot(EquipmentSlot slot, CallbackInfoReturnable<ItemStack> ci) {
-        if (FirstPersonModelCore.instance.isRenderingPlayer() && Minecraft.getInstance().isSameThread()
+        if (FirstPersonModelCore.instance.isRenderingPlayerRaw() && Minecraft.getInstance().isSameThread()
                 && (Object) this instanceof Player player) {
             if (slot == EquipmentSlot.HEAD) {
                 ci.setReturnValue(ItemStack.EMPTY);

--- a/src/main/java/dev/tr7zw/firstperson/mixins/RenderDispatcherMixin.java
+++ b/src/main/java/dev/tr7zw/firstperson/mixins/RenderDispatcherMixin.java
@@ -2,12 +2,16 @@ package dev.tr7zw.firstperson.mixins;
 
 import com.mojang.blaze3d.vertex.*;
 import dev.tr7zw.firstperson.*;
+import dev.tr7zw.firstperson.access.*;
 import lombok.*;
 import net.minecraft.client.*;
 import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.entity.*;
 //? if >= 1.21.2
 import net.minecraft.client.renderer.entity.state.*;
+//? if >= 26.1 {
+import net.minecraft.client.renderer.state.level.*;
+//? }
 import net.minecraft.world.level.*;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.*;
@@ -33,8 +37,60 @@ public abstract class RenderDispatcherMixin {
 
     private static Minecraft fpmMcInstance = Minecraft.getInstance();
 
-    //? if >= 1.21.9 {
+    //? if >= 26.1 {
 
+    private boolean fpmSubmittingCameraEntity = false;
+
+    /**
+     * YSM (and potentially other mods) defer their animation evaluation to the
+     * submit of the render state and check {@link FirstPersonModelCore#isRenderingPlayer()}
+     * at that point to decide when to hide the head. Two windows keep the flag
+     * up for exactly those moments:
+     * - extraction of the camera entity: widens the flag (without marking the
+     *   states themselves, so third party captures stay unflagged) which makes
+     *   YSM attach its first person context and re-evaluate the head visibility
+     *   on every submit,
+     * - the submit of the state FPM extracted (marked via isCameraEntity): the
+     *   only evaluation that must see the flag up, hiding the head for the
+     *   actual frame render. Evaluations triggered by other mods (RealCamera,
+     *   GUIs) run with the flag down and keep the model headed.
+     */
+    @Inject(method = "extractEntity(Lnet/minecraft/world/entity/Entity;F)Lnet/minecraft/client/renderer/entity/state/EntityRenderState;",
+            at = @At("HEAD"), expect = 0, require = 0)
+    private void fpmExtractStart(Entity entity, float f, CallbackInfoReturnable<EntityRenderState> cir) {
+        Minecraft mc = Minecraft.getInstance();
+        if (entity == mc.getCameraEntity() && mc.options.getCameraType() == CameraType.FIRST_PERSON
+                && FirstPersonModelCore.instance.getLogicHandler().shouldApplyThirdPerson(false)) {
+            FirstPersonModelCore.cameraEntityExtract = true;
+        }
+    }
+
+    @Inject(method = "extractEntity(Lnet/minecraft/world/entity/Entity;F)Lnet/minecraft/client/renderer/entity/state/EntityRenderState;",
+            at = @At("TAIL"), expect = 0, require = 0)
+    private void fpmExtractEnd(Entity entity, float f, CallbackInfoReturnable<EntityRenderState> cir) {
+        FirstPersonModelCore.cameraEntityExtract = false;
+    }
+
+    @Inject(method = "submit(Lnet/minecraft/client/renderer/entity/state/EntityRenderState;Lnet/minecraft/client/renderer/state/level/CameraRenderState;DDDLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;)V",
+            at = @At("HEAD"), expect = 0, require = 0)
+    private void fpmSubmitStart(EntityRenderState renderState, CameraRenderState camera, double x, double y, double z,
+            PoseStack poseStack, SubmitNodeCollector submitNodeCollector, CallbackInfo ci) {
+        if (renderState instanceof LivingEntityRenderState livingState
+                && ((LivingEntityRenderStateAccess) (Object) livingState).isCameraEntity()) {
+            fpmSubmittingCameraEntity = true;
+            FirstPersonModelCore.instance.setRenderingPlayer(true);
+        }
+    }
+
+    @Inject(method = "submit(Lnet/minecraft/client/renderer/entity/state/EntityRenderState;Lnet/minecraft/client/renderer/state/level/CameraRenderState;DDDLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;)V",
+            at = @At("TAIL"), expect = 0, require = 0)
+    private void fpmSubmitEnd(EntityRenderState renderState, CameraRenderState camera, double x, double y, double z,
+            PoseStack poseStack, SubmitNodeCollector submitNodeCollector, CallbackInfo ci) {
+        if (fpmSubmittingCameraEntity) {
+            fpmSubmittingCameraEntity = false;
+            FirstPersonModelCore.instance.setRenderingPlayer(false);
+        }
+    }
     //? } else if >= 1.21.3 {
     /*
     


### PR DESCRIPTION
## Problem

When playing with [Yes Steve Model](https://www.modrinth.com/mod/ysm) on 1.21.9+ (26.1.x), the
YSM player model keeps its head rendered in first person, so the camera sits inside the head.
On 1.20.1 the head hiding worked fine.

## Root cause

YSM is compatible through `FirstPersonAPI#isRenderingPlayer()`. On 1.20.1 the flag is raised
around FirstPerson's synchronous player render, which is exactly when YSM evaluates its
animation, so the head gets hidden.

On 1.21.9+ the render pipeline is split into state extraction and submission, and YSM 2.6.5
now builds its render data at extraction time and defers the animation evaluation (including
the head visibility write) to the submit of that state. FirstPerson only raised the flag
around its own extraction, so:

- the deferred evaluation ran with the flag already down → the head stayed visible
- YSM's own re-extraction of the local player (end of the level extract) force-evaluated the
  animation with the flag down and memoized that result, since evaluation results are cached
  per render data

## Fix

Two narrow windows around `EntityRenderDispatcher`, enabled for `>= 26.1`:

1. **Extraction window** — while the camera entity's render state is extracted and the mod is
   active, widen `isRenderingPlayer()` via a separate flag (`cameraEntityExtract`) instead of
   the regular one. YSM then attaches its first person context on *every* extraction of the
   local player (including its own re-extractions) and re-evaluates head visibility on each
   submit.
2. **Submit window** — only the render state FirstPerson extracted itself (marked via the
   existing `isCameraEntity` state flag) raises the regular flag during its submit. That is
   the one evaluation that must hide the head for the actual frame render.

Because evaluations triggered by other mods run with the flag down, YSM's hide block
explicitly resets the head state — so RealCamera bindings, its model view screen and GUI
captures keep rendering the full model. Accordingly:

- `LivingEntityRendererMixin` and the helmet removal in `PlayerMixin` now use the un-widened
  flag (`isRenderingPlayerRaw()`), so only states extracted by FirstPerson are marked
- all new injections use `require = 0` / `expect = 0` and are preprocessor-gated to
  `>= 26.1`, leaving 1.20.1 and every other version untouched

## Testing

- MC 26.1.2 + NeoForge 26.1.2.105 + YSM 2.6.5: head is hidden in first person again
- MC 26.1.2 + NeoForge + YSM + RealCamera: camera binding works, binding screen shows the
  full model, body render unaffected
- MC 26.1.2 + NeoForge + RealCamera (no YSM): no regression
- Build verified for 26.1-neoforge, 26.1-fabric; 1.20.1-fabric, 1.21.11-fabric and
  26.2-fabric compile with the new code fully preprocessed out / behavior unchanged

**PS:This PR was generated with the help of AI and requires careful review.**